### PR TITLE
improve x11 sanitizer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,9 +4,6 @@ project(wemeet-wayland-screencast LANGUAGES C CXX)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-# Find opencv
-find_package(OpenCV REQUIRED)
-
 # Find PkgConfig
 find_package(PkgConfig REQUIRED)
 
@@ -16,8 +13,6 @@ pkg_check_modules(GIO REQUIRED gio-2.0)
 pkg_check_modules(LIBPORTAL REQUIRED libportal)
 # pipewire
 pkg_check_modules(PIPEWIRE REQUIRED libpipewire-0.3)
-# libxdo
-pkg_check_modules(LIBXDO REQUIRED libxdo)
 
 
 find_package(X11 REQUIRED)
@@ -37,17 +32,13 @@ function(add_compile_options_for TARGET_NAME)
   target_include_directories(${TARGET_NAME} PRIVATE ${PIPEWIRE_INCLUDE_DIRS})
   target_compile_options(${TARGET_NAME} PRIVATE ${PIPEWIRE_CFLAGS_OTHER})
 
-  # libxdo
-  target_link_libraries(${TARGET_NAME} PRIVATE ${LIBXDO_LIBRARIES})
-  target_include_directories(${TARGET_NAME} PRIVATE ${LIBXDO_INCLUDE_DIRS})
-
   # include current directory
   target_include_directories(${TARGET_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 
   # opencv
   target_include_directories(${TARGET_NAME} PRIVATE ${OpenCV_INCLUDE_DIRS})
 
-  target_link_libraries(hook PRIVATE X11::X11)
+  target_link_libraries(${TARGET_NAME} PRIVATE X11::X11)
 
 endfunction()
 


### PR DESCRIPTION
1. 检测到全屏窗口，则直接选取。可以显著地减少等待时间。
2. 移除对 xdo 的依赖，统一使用 `XUnmapWindow`. 目前的方案在 gnome 43 和 kde 5 上测试均能工作。