### PR TITLE
fix: empty XDG_SESSION_DESKTOP cause abort

### DIFF
--- a/payload.hpp
+++ b/payload.hpp
@@ -30,11 +30,11 @@ enum class DEType {
 inline DEType get_current_de_type(){
   // get the DE type using envvar "XDG_SESSION_DESKTOP"
   char* xdg_session_desktop = std::getenv("XDG_SESSION_DESKTOP");
-  std::string xdg_session_desktop_str = xdg_session_desktop;
-  std::string xdg_session_desktop_lower = toLowerString(xdg_session_desktop_str);
   if (xdg_session_desktop == nullptr) {
     return DEType::Unknown;
   }
+  std::string xdg_session_desktop_str = xdg_session_desktop;
+  std::string xdg_session_desktop_lower = toLowerString(xdg_session_desktop_str);
   if (std::string(xdg_session_desktop) == "KDE") {
     return DEType::KDE;
   } else if (std::string(xdg_session_desktop) == "gnome") {


### PR DESCRIPTION
Program will abort without environment variable XDG_SESSION_DESKTOP.

<details>
<summary>log</summary>

```
2025-01-04 08:11:54|140052755221440|xnn.XNNHandleMonitor|xnnhandlemonitor.cpp:35||regist handle,type:0 handle:415484544
2025-01-04 08:11:54|140052755221440|xnn.XNNRTResource|xnnrtresource.cpp:20||the acc thread cnt is 0
2025-01-04 08:11:54|140052755221440|xnn.XNNContext|xnncontext.cpp:99||init xnn context succ
Call
MicButtonQTView::OnViewStatefulChanged():btn_title:选择音频
MicButtonQTView::OnViewStatefulChanged():btn_title:选择音频
MicButtonQTView::OnViewStatefulChanged():btn_title:选择音频
MicButtonQTView::OnViewStatefulChanged():btn_title:选择音频
MicButtonQTView::OnViewStatefulChanged():btn_title:选择音频
MicButtonQTView::OnViewStatefulChanged():btn_title:解除静音
MicButtonQTView::OnViewStatefulChanged():btn_title:静音
terminate called after throwing an instance of 'std::logic_error'
  what():  basic_string: construction from null is not valid
fish: Job 1, 'result/bin/wemeet-xwayland' terminated by signal SIGABRT (Abort)
```

</details>

<details>
<summary>
backtrace
</summary>

```
(gdb) bt

#0  0x00007fcf30ead7d7 in std::terminate() ()
   from /nix/store/bpq1s72cw9qb2fs8mnmlw6hn2c7iy0ss-gc
#1  0x00007fcf30ebf487 in __cxa_throw ()
   from /nix/store/bpq1s72cw9qb2fs8mnmlw6hn2c7iy0ss-gc
#2  0x00007fcf30eb0342 in std::__throw_logic_error(cha
   from /nix/store/bpq1s72cw9qb2fs8mnmlw6hn2c7iy0ss-gc
#3  0x00007fcf32ea0204 in std::__cxx11::basic_string<c
    this=0x7fce59ffa440, __s=0x0)
    at /nix/store/l89iqc7am6i60y8vk507zwrzxf0wcd3v-gcc
#4  get_current_de_type ()
    at /home/xin/repo/wemeet-wayland-screenshare/paylo
#5  0x00007fcf32e9ba5b in XdpScreencastPortal::XdpScreencastPortal (this=0x7fce38001e30)
    at /home/xin/repo/wemeet-wayland-screenshare/payload.hpp:88
--Type <RET> for more, q to quit, c to continue without paging--quit
#6  XShmAttachHook ()
    at /home/xin/repo/wemeet-wayland-screenshare/hook.cpp:54
```

</details>